### PR TITLE
fixing get_connect_name

### DIFF
--- a/R/connect.R
+++ b/R/connect.R
@@ -74,7 +74,8 @@ get_connect_name = function() {
   on.exit(close(git_config))
   l = readLines(git_config)
   git_url = l[grep(pattern = "\turl", l) ]
-  pkg = stringr::str_match(git_url, "(jumpingrivers-notes|course_notes)/(.*)/(.*)_notes.git")
+  pkg = stringr::str_match(git_url,
+                           "(jumpingrivers-notes|course_notes)/(.*)/(.*)_notes")
   pkg = pkg[, length(pkg)]
   pkg
 }

--- a/R/connect.R
+++ b/R/connect.R
@@ -74,7 +74,7 @@ get_connect_name = function() {
   on.exit(close(git_config))
   l = readLines(git_config)
   git_url = l[grep(pattern = "\turl", l) ]
-  pkg = stringr::str_match(git_url, "course_notes/(.*)/(.*)_notes.git")
+  pkg = stringr::str_match(git_url, "(jumpingrivers-notes|course_notes)/(.*)/(.*)_notes.git")
   pkg = pkg[, length(pkg)]
   pkg
 }


### PR DESCRIPTION
Due to us moving notes from course_notes to jumpingrivers-notes, the line of code using regex to grab the project title was failing. Small edit